### PR TITLE
[DATA] 프로보노 데이터를 공공데이터로 대체

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -588,4 +588,10 @@ hs_err_pid*
 
 !/gradle/wrapper/gradle-wrapper.jar
 
+### AWS
+
+*.pem
+config.py
+welfare_for_embedding.csv
+
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,visualstudiocode,androidstudio,pycharm,node,jupyternotebooks,python

--- a/.gitignore
+++ b/.gitignore
@@ -592,6 +592,6 @@ hs_err_pid*
 
 *.pem
 config.py
-welfare_for_embedding.csv
+*.csv
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,visualstudiocode,androidstudio,pycharm,node,jupyternotebooks,python

--- a/data/crawling/probono_to_app_data.ipynb
+++ b/data/crawling/probono_to_app_data.ipynb
@@ -1,0 +1,1294 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "aa2935a1",
+   "metadata": {},
+   "source": [
+    "## 프로보노 공모전에서 앱용 데이터로 변환\n",
+    "- 크롤링에서 공공데이터 API를 사용"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ff916f3",
+   "metadata": {},
+   "source": [
+    "### 공공데이터 API로 데이터 가져오기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fd602de7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import pprint\n",
+    "import json\n",
+    "import pandas as pd\n",
+    "\n",
+    "url = 'https://api.odcloud.kr/api/15083323/v1/uddi:541ea710-74e8-4010-b69e-e3cb8b38b3fc?page=1&perPage=400&serviceKey=LL%2FWwEZVOVH0Zl%2BA4ukk09hBFr06qaWdqnjIm%2ByV7WO1O92U5Dj4IcgEHK4Od7pdTibXe662u1oLZxMmKPwIyQ%3D%3D'\n",
+    "\n",
+    "response = requests.get(url)\n",
+    "contents = response.text\n",
+    "json_ob = json.loads(contents)\n",
+    "\n",
+    "current_count = json_ob['currentCount']\n",
+    "welfares = json_ob['data']\n",
+    "\n",
+    "welfares_origin_df= pd.json_normalize(welfares)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6a815e44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "welfares_df = welfares_origin_df[['서비스아이디', '서비스명', '서비스요약', '대표문의', '사이트']].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fdf8a0ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>서비스아이디</th>\n",
+       "      <th>서비스명</th>\n",
+       "      <th>서비스요약</th>\n",
+       "      <th>대표문의</th>\n",
+       "      <th>사이트</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10</td>\n",
+       "      <td>(북한이탈주민) 탈북청소년 교육지원</td>\n",
+       "      <td>탈북청소년의 학교생활 적응 지원을 통해 대한민국의 건강한 구성원으로 자립할 수 있도...</td>\n",
+       "      <td>남북하나재단 콜센터 1577-6635</td>\n",
+       "      <td>북한이탈주민지원재단 교육지원부 www.koreahana.or.kr 통일부 정착지원과...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>18</td>\n",
+       "      <td>(특수교육대상자) 치료지원서비스</td>\n",
+       "      <td>특수교육대상자의 효과적인 교육을 위해 다양한 서비스를 제공합니다.</td>\n",
+       "      <td>교육부 민원콜센터 02-6222-6060</td>\n",
+       "      <td>교육부 http://www.moe.go.kr</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>266</td>\n",
+       "      <td>6.25자녀수당</td>\n",
+       "      <td>6.25 전쟁 중 전사하거나 순직한 전몰군경 혹은 순직군경 자녀의 생활안정과 복지향...</td>\n",
+       "      <td>보훈상담센터 1577-0606</td>\n",
+       "      <td>국가보훈처 http://www.mpva.go.kr/</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>19</td>\n",
+       "      <td>WEE 클래스 상담지원</td>\n",
+       "      <td>초중고 학교부적응 학생 및 위기학생, 일반학생에 대한 학교생활 적응 조력 및 치유를...</td>\n",
+       "      <td>학교안전통합시스템 043)5309-182, 184</td>\n",
+       "      <td>학생안전통합시스템 www.wee.go.kr</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>357</td>\n",
+       "      <td>가사·간병 방문 지원사업</td>\n",
+       "      <td>일상생활이 어려운 저소득층 가정에 간병·가사 서비스를 지원하여 취약계층의 생활 안정...</td>\n",
+       "      <td>보건복지콜센터 129</td>\n",
+       "      <td>사회서비스바우처 http://www.socialservice.or.kr 보건복지부 ...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   서비스아이디                 서비스명  \\\n",
+       "0      10  (북한이탈주민) 탈북청소년 교육지원   \n",
+       "1      18    (특수교육대상자) 치료지원서비스   \n",
+       "2     266             6.25자녀수당   \n",
+       "3      19         WEE 클래스 상담지원   \n",
+       "4     357        가사·간병 방문 지원사업   \n",
+       "\n",
+       "                                               서비스요약  \\\n",
+       "0  탈북청소년의 학교생활 적응 지원을 통해 대한민국의 건강한 구성원으로 자립할 수 있도...   \n",
+       "1               특수교육대상자의 효과적인 교육을 위해 다양한 서비스를 제공합니다.   \n",
+       "2  6.25 전쟁 중 전사하거나 순직한 전몰군경 혹은 순직군경 자녀의 생활안정과 복지향...   \n",
+       "3  초중고 학교부적응 학생 및 위기학생, 일반학생에 대한 학교생활 적응 조력 및 치유를...   \n",
+       "4  일상생활이 어려운 저소득층 가정에 간병·가사 서비스를 지원하여 취약계층의 생활 안정...   \n",
+       "\n",
+       "                          대표문의  \\\n",
+       "0         남북하나재단 콜센터 1577-6635   \n",
+       "1       교육부 민원콜센터 02-6222-6060   \n",
+       "2             보훈상담센터 1577-0606   \n",
+       "3  학교안전통합시스템 043)5309-182, 184   \n",
+       "4                  보건복지콜센터 129   \n",
+       "\n",
+       "                                                 사이트  \n",
+       "0  북한이탈주민지원재단 교육지원부 www.koreahana.or.kr 통일부 정착지원과...  \n",
+       "1                           교육부 http://www.moe.go.kr  \n",
+       "2                       국가보훈처 http://www.mpva.go.kr/  \n",
+       "3                            학생안전통합시스템 www.wee.go.kr  \n",
+       "4  사회서비스바우처 http://www.socialservice.or.kr 보건복지부 ...  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "welfares_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "922be3c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 357 entries, 0 to 356\n",
+      "Data columns (total 5 columns):\n",
+      " #   Column  Non-Null Count  Dtype \n",
+      "---  ------  --------------  ----- \n",
+      " 0   서비스아이디  357 non-null    int64 \n",
+      " 1   서비스명    357 non-null    object\n",
+      " 2   서비스요약   357 non-null    object\n",
+      " 3   대표문의    356 non-null    object\n",
+      " 4   사이트     317 non-null    object\n",
+      "dtypes: int64(1), object(4)\n",
+      "memory usage: 14.1+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "welfares_df.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45720a38",
+   "metadata": {},
+   "source": [
+    "### 전처리 수행"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2b45356b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "## summary, who, what, criteria 등 모두 해당하기\n",
+    "def preprocess_summary(text):\n",
+    "    if not text:\n",
+    "        return '해당없음'\n",
+    "    text=re.sub(r'\\t', '', text)\n",
+    "    text=re.sub(r'^(\\n)+|(\\n)+$','', text)\n",
+    "    text=re.sub(r'<BR />', '\\n', text)\n",
+    "    return text\n",
+    "\n",
+    "## call 과 site의 경우\n",
+    "def preprocess_call(text):\n",
+    "    if not text:\n",
+    "        return '해당없음'\n",
+    "    text=re.sub('\\t', '', text)\n",
+    "    text=re.sub(r'^(\\n)+|(\\n)+$','', text)\n",
+    "    text=re.sub(r'\\n', ' ', text)\n",
+    "    text=re.sub(r'☎', '', text)\n",
+    "    return text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cdab06b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "welfares_df['서비스요약'] = welfares_df['서비스요약'].map(preprocess_summary)\n",
+    "welfares_df[['대표문의', '사이트']] = welfares_df[['대표문의', '사이트']].applymap(preprocess_call)\n",
+    "welfares_df['서비스아이디']=welfares_df['서비스아이디'].astype(str) # sql에 넣기 위한 작업"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ed7b13b",
+   "metadata": {},
+   "source": [
+    "### 기존 DB와 API 사이의 공통적인 복지 찾기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d8a79558",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def preprocess_delete_all(text):\n",
+    "    return re.sub('[^A-Za-z0-9가-힣]', '', text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 203,
+   "id": "87f6ec91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mysql.connector\n",
+    "import config\n",
+    "\n",
+    "cnxn = mysql.connector.connect(**config.DATABASE_CONFIG)\n",
+    "cursor = cnxn.cursor(prepared=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 204,
+   "id": "07cbc561",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = (\"SELECT welfare_id, title FROM welfare\")\n",
+    "cursor.execute(query)\n",
+    "\n",
+    "old_welfares = []\n",
+    "for old_welfare in cursor:\n",
+    "    old_welfares.append([old_welfare[0], preprocess_delete_all(old_welfare[1])])\n",
+    "old_welfares_df = pd.DataFrame(old_welfares, columns=['서비스아이디', '서비스명'])\n",
+    "old_welfares_df['서비스아이디']=old_welfares_df['서비스아이디'].astype(str) # sql에 넣기 위한 작업"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56050b3e",
+   "metadata": {},
+   "source": [
+    "### 기존 db 복지정보에서 가지고 있는 복지 정보"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 205,
+   "id": "d0215402",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_welfares_df = welfares_df[['서비스아이디', '서비스명']].copy()\n",
+    "new_welfares_df['서비스명'] = new_welfares_df['서비스명'].map(preprocess_delete_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 206,
+   "id": "3828c735",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inner_welfares_df = pd.merge(old_welfares_df, new_welfares_df, how='inner', on='서비스명')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 207,
+   "id": "0b9e7304",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>서비스아이디_x</th>\n",
+       "      <th>서비스명</th>\n",
+       "      <th>서비스아이디_y</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>청소년한부모자립지원</td>\n",
+       "      <td>155</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>긴급복지생계지원</td>\n",
+       "      <td>303</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>교육복지우선지원사업</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>방과후보육료지원</td>\n",
+       "      <td>294</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>취약계층환경성질환예방사업</td>\n",
+       "      <td>90</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  서비스아이디_x           서비스명 서비스아이디_y\n",
+       "0        0     청소년한부모자립지원      155\n",
+       "1        1       긴급복지생계지원      303\n",
+       "2        2     교육복지우선지원사업       20\n",
+       "3        3       방과후보육료지원      294\n",
+       "4        4  취약계층환경성질환예방사업       90"
+      ]
+     },
+     "execution_count": 207,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "inner_welfares_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 208,
+   "id": "f1e7fac3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 351 entries, 0 to 350\n",
+      "Data columns (total 3 columns):\n",
+      " #   Column    Non-Null Count  Dtype \n",
+      "---  ------    --------------  ----- \n",
+      " 0   서비스아이디_x  351 non-null    object\n",
+      " 1   서비스명      351 non-null    object\n",
+      " 2   서비스아이디_y  351 non-null    object\n",
+      "dtypes: object(3)\n",
+      "memory usage: 11.0+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "inner_welfares_df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 209,
+   "id": "13d6657c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(351, 3)"
+      ]
+     },
+     "execution_count": 209,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "inner_welfares_df.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29e49a7d",
+   "metadata": {},
+   "source": [
+    "### 중복되어 있는 복지 정보가 존재함(db 값이 잘못된 경우)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 210,
+   "id": "c6ddc8bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "351"
+      ]
+     },
+     "execution_count": 210,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(inner_welfares_df['서비스아이디_y'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 211,
+   "id": "3e83190f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "349"
+      ]
+     },
+     "execution_count": 211,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(set(inner_welfares_df['서비스아이디_y']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 212,
+   "id": "d89e4a96",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('15281', 2),\n",
+       " ('129', 2),\n",
+       " ('155', 1),\n",
+       " ('303', 1),\n",
+       " ('20', 1),\n",
+       " ('294', 1),\n",
+       " ('90', 1),\n",
+       " ('58', 1),\n",
+       " ('216', 1),\n",
+       " ('352', 1),\n",
+       " ('12394', 1),\n",
+       " ('200', 1),\n",
+       " ('16489', 1),\n",
+       " ('213', 1),\n",
+       " ('61', 1),\n",
+       " ('226', 1),\n",
+       " ('357', 1),\n",
+       " ('195', 1),\n",
+       " ('196', 1),\n",
+       " ('66', 1),\n",
+       " ('73', 1),\n",
+       " ('190', 1),\n",
+       " ('353', 1),\n",
+       " ('46', 1),\n",
+       " ('82', 1),\n",
+       " ('227', 1),\n",
+       " ('229', 1),\n",
+       " ('171', 1),\n",
+       " ('159', 1),\n",
+       " ('138', 1),\n",
+       " ('163', 1),\n",
+       " ('16440', 1),\n",
+       " ('143', 1),\n",
+       " ('223', 1),\n",
+       " ('133', 1),\n",
+       " ('17521', 1),\n",
+       " ('220', 1),\n",
+       " ('126', 1),\n",
+       " ('28', 1),\n",
+       " ('13', 1),\n",
+       " ('14', 1),\n",
+       " ('12405', 1),\n",
+       " ('12392', 1),\n",
+       " ('110', 1),\n",
+       " ('12391', 1),\n",
+       " ('12396', 1),\n",
+       " ('136', 1),\n",
+       " ('221', 1),\n",
+       " ('306', 1),\n",
+       " ('147', 1),\n",
+       " ('230', 1),\n",
+       " ('12395', 1),\n",
+       " ('282', 1),\n",
+       " ('16', 1),\n",
+       " ('165', 1),\n",
+       " ('16437', 1),\n",
+       " ('17162', 1),\n",
+       " ('17520', 1),\n",
+       " ('2', 1),\n",
+       " ('341', 1),\n",
+       " ('144', 1),\n",
+       " ('318', 1),\n",
+       " ('335', 1),\n",
+       " ('52', 1),\n",
+       " ('191', 1),\n",
+       " ('241', 1),\n",
+       " ('158', 1),\n",
+       " ('16493', 1),\n",
+       " ('298', 1),\n",
+       " ('300', 1),\n",
+       " ('349', 1),\n",
+       " ('314', 1),\n",
+       " ('118', 1),\n",
+       " ('189', 1),\n",
+       " ('293', 1),\n",
+       " ('16488', 1),\n",
+       " ('209', 1),\n",
+       " ('355', 1),\n",
+       " ('179', 1),\n",
+       " ('187', 1),\n",
+       " ('87', 1),\n",
+       " ('119', 1),\n",
+       " ('232', 1),\n",
+       " ('54', 1),\n",
+       " ('16496', 1),\n",
+       " ('338', 1),\n",
+       " ('250', 1),\n",
+       " ('47', 1),\n",
+       " ('55', 1),\n",
+       " ('88', 1),\n",
+       " ('18', 1),\n",
+       " ('302', 1),\n",
+       " ('48', 1),\n",
+       " ('12393', 1),\n",
+       " ('17524', 1),\n",
+       " ('333', 1),\n",
+       " ('280', 1),\n",
+       " ('35', 1),\n",
+       " ('39', 1),\n",
+       " ('16494', 1),\n",
+       " ('330', 1),\n",
+       " ('340', 1),\n",
+       " ('36', 1),\n",
+       " ('128', 1),\n",
+       " ('22', 1),\n",
+       " ('296', 1),\n",
+       " ('336', 1),\n",
+       " ('16378', 1),\n",
+       " ('27', 1),\n",
+       " ('94', 1),\n",
+       " ('358', 1),\n",
+       " ('16439', 1),\n",
+       " ('264', 1),\n",
+       " ('359', 1),\n",
+       " ('134', 1),\n",
+       " ('177', 1),\n",
+       " ('331', 1),\n",
+       " ('178', 1),\n",
+       " ('181', 1),\n",
+       " ('337', 1),\n",
+       " ('243', 1),\n",
+       " ('135', 1),\n",
+       " ('57', 1),\n",
+       " ('116', 1),\n",
+       " ('157', 1),\n",
+       " ('16443', 1),\n",
+       " ('19', 1),\n",
+       " ('197', 1),\n",
+       " ('23', 1),\n",
+       " ('65', 1),\n",
+       " ('68', 1),\n",
+       " ('76', 1),\n",
+       " ('149', 1),\n",
+       " ('16441', 1),\n",
+       " ('273', 1),\n",
+       " ('63', 1),\n",
+       " ('301', 1),\n",
+       " ('8', 1),\n",
+       " ('79', 1),\n",
+       " ('271', 1),\n",
+       " ('6', 1),\n",
+       " ('10', 1),\n",
+       " ('304', 1),\n",
+       " ('60', 1),\n",
+       " ('168', 1),\n",
+       " ('62', 1),\n",
+       " ('69', 1),\n",
+       " ('148', 1),\n",
+       " ('12399', 1),\n",
+       " ('175', 1),\n",
+       " ('80', 1),\n",
+       " ('164', 1),\n",
+       " ('360', 1),\n",
+       " ('160', 1),\n",
+       " ('351', 1),\n",
+       " ('74', 1),\n",
+       " ('16495', 1),\n",
+       " ('40', 1),\n",
+       " ('236', 1),\n",
+       " ('15282', 1),\n",
+       " ('16478', 1),\n",
+       " ('281', 1),\n",
+       " ('252', 1),\n",
+       " ('16491', 1),\n",
+       " ('245', 1),\n",
+       " ('81', 1),\n",
+       " ('108', 1),\n",
+       " ('150', 1),\n",
+       " ('299', 1),\n",
+       " ('263', 1),\n",
+       " ('16438', 1),\n",
+       " ('78', 1),\n",
+       " ('17522', 1),\n",
+       " ('272', 1),\n",
+       " ('75', 1),\n",
+       " ('25', 1),\n",
+       " ('45', 1),\n",
+       " ('49', 1),\n",
+       " ('77', 1),\n",
+       " ('70', 1),\n",
+       " ('17160', 1),\n",
+       " ('17164', 1),\n",
+       " ('125', 1),\n",
+       " ('124', 1),\n",
+       " ('13464', 1),\n",
+       " ('15', 1),\n",
+       " ('316', 1),\n",
+       " ('11', 1),\n",
+       " ('311', 1),\n",
+       " ('313', 1),\n",
+       " ('42', 1),\n",
+       " ('317', 1),\n",
+       " ('9', 1),\n",
+       " ('328', 1),\n",
+       " ('169', 1),\n",
+       " ('12', 1),\n",
+       " ('312', 1),\n",
+       " ('30', 1),\n",
+       " ('31', 1),\n",
+       " ('7', 1),\n",
+       " ('180', 1),\n",
+       " ('239', 1),\n",
+       " ('323', 1),\n",
+       " ('43', 1),\n",
+       " ('85', 1),\n",
+       " ('86', 1),\n",
+       " ('343', 1),\n",
+       " ('26', 1),\n",
+       " ('278', 1),\n",
+       " ('91', 1),\n",
+       " ('151', 1),\n",
+       " ('240', 1),\n",
+       " ('267', 1),\n",
+       " ('285', 1),\n",
+       " ('113', 1),\n",
+       " ('29', 1),\n",
+       " ('211', 1),\n",
+       " ('255', 1),\n",
+       " ('261', 1),\n",
+       " ('270', 1),\n",
+       " ('319', 1),\n",
+       " ('93', 1),\n",
+       " ('265', 1),\n",
+       " ('279', 1),\n",
+       " ('83', 1),\n",
+       " ('222', 1),\n",
+       " ('259', 1),\n",
+       " ('269', 1),\n",
+       " ('275', 1),\n",
+       " ('297', 1),\n",
+       " ('309', 1),\n",
+       " ('260', 1),\n",
+       " ('106', 1),\n",
+       " ('107', 1),\n",
+       " ('123', 1),\n",
+       " ('202', 1),\n",
+       " ('84', 1),\n",
+       " ('98', 1),\n",
+       " ('122', 1),\n",
+       " ('344', 1),\n",
+       " ('114', 1),\n",
+       " ('105', 1),\n",
+       " ('325', 1),\n",
+       " ('137', 1),\n",
+       " ('37', 1),\n",
+       " ('56', 1),\n",
+       " ('182', 1),\n",
+       " ('204', 1),\n",
+       " ('247', 1),\n",
+       " ('253', 1),\n",
+       " ('266', 1),\n",
+       " ('276', 1),\n",
+       " ('146', 1),\n",
+       " ('17515', 1),\n",
+       " ('176', 1),\n",
+       " ('185', 1),\n",
+       " ('201', 1),\n",
+       " ('41', 1),\n",
+       " ('97', 1),\n",
+       " ('140', 1),\n",
+       " ('152', 1),\n",
+       " ('3', 1),\n",
+       " ('34', 1),\n",
+       " ('16497', 1),\n",
+       " ('242', 1),\n",
+       " ('251', 1),\n",
+       " ('254', 1),\n",
+       " ('234', 1),\n",
+       " ('274', 1),\n",
+       " ('291', 1),\n",
+       " ('51', 1),\n",
+       " ('207', 1),\n",
+       " ('350', 1),\n",
+       " ('244', 1),\n",
+       " ('246', 1),\n",
+       " ('188', 1),\n",
+       " ('153', 1),\n",
+       " ('218', 1),\n",
+       " ('348', 1),\n",
+       " ('173', 1),\n",
+       " ('284', 1),\n",
+       " ('203', 1),\n",
+       " ('258', 1),\n",
+       " ('268', 1),\n",
+       " ('277', 1),\n",
+       " ('104', 1),\n",
+       " ('17', 1),\n",
+       " ('17161', 1),\n",
+       " ('184', 1),\n",
+       " ('219', 1),\n",
+       " ('212', 1),\n",
+       " ('238', 1),\n",
+       " ('99', 1),\n",
+       " ('145', 1),\n",
+       " ('307', 1),\n",
+       " ('345', 1),\n",
+       " ('15207', 1),\n",
+       " ('257', 1),\n",
+       " ('170', 1),\n",
+       " ('262', 1),\n",
+       " ('13463', 1),\n",
+       " ('283', 1),\n",
+       " ('192', 1),\n",
+       " ('235', 1),\n",
+       " ('1', 1),\n",
+       " ('308', 1),\n",
+       " ('17173', 1),\n",
+       " ('44', 1),\n",
+       " ('326', 1),\n",
+       " ('356', 1),\n",
+       " ('132', 1),\n",
+       " ('315', 1),\n",
+       " ('194', 1),\n",
+       " ('161', 1),\n",
+       " ('199', 1),\n",
+       " ('210', 1),\n",
+       " ('256', 1),\n",
+       " ('17518', 1),\n",
+       " ('198', 1),\n",
+       " ('16492', 1),\n",
+       " ('131', 1),\n",
+       " ('193', 1),\n",
+       " ('127', 1),\n",
+       " ('346', 1),\n",
+       " ('237', 1),\n",
+       " ('249', 1),\n",
+       " ('248', 1),\n",
+       " ('12398', 1),\n",
+       " ('17519', 1),\n",
+       " ('50', 1),\n",
+       " ('324', 1),\n",
+       " ('139', 1),\n",
+       " ('141', 1),\n",
+       " ('12400', 1),\n",
+       " ('16490', 1),\n",
+       " ('59', 1),\n",
+       " ('322', 1),\n",
+       " ('162', 1),\n",
+       " ('5', 1),\n",
+       " ('327', 1),\n",
+       " ('305', 1),\n",
+       " ('4', 1),\n",
+       " ('17150', 1),\n",
+       " ('17523', 1),\n",
+       " ('121', 1),\n",
+       " ('292', 1),\n",
+       " ('12397', 1),\n",
+       " ('295', 1),\n",
+       " ('329', 1)]"
+      ]
+     },
+     "execution_count": 212,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "Counter(inner_welfares_df['서비스아이디_y']).most_common()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 213,
+   "id": "eb12e4bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   서비스아이디_x        서비스명 서비스아이디_y\n",
+      "59       59  산림복지서비스이용권    15281\n",
+      "60      399  산림복지서비스이용권    15281\n",
+      "    서비스아이디_x         서비스명 서비스아이디_y\n",
+      "196      201  북한이탈주민의료비지원      129\n",
+      "197      374  북한이탈주민의료비지원      129\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(inner_welfares_df[inner_welfares_df['서비스아이디_y']=='15281'])\n",
+    "print(inner_welfares_df[inner_welfares_df['서비스아이디_y']=='129' ])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 214,
+   "id": "db7917a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(349, 3)"
+      ]
+     },
+     "execution_count": 214,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "inner_welfares_df =inner_welfares_df.drop_duplicates(subset=['서비스아이디_y'], keep='first')\n",
+    "inner_welfares_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 215,
+   "id": "dfc19758",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   서비스아이디_x        서비스명 서비스아이디_y\n",
+      "59       59  산림복지서비스이용권    15281\n",
+      "    서비스아이디_x         서비스명 서비스아이디_y\n",
+      "196      201  북한이탈주민의료비지원      129\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(inner_welfares_df[inner_welfares_df['서비스아이디_y']=='15281'])\n",
+    "print(inner_welfares_df[inner_welfares_df['서비스아이디_y']=='129' ])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0250aeb6",
+   "metadata": {},
+   "source": [
+    "### 기존 db 복지정보에서 가지고 있지 않은 새로운 복지정보 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 216,
+   "id": "1f2e3a37",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['21', '다문화탈북학생멘토링'],\n",
+       " ['33', '독거노인사회관계활성화지원'],\n",
+       " ['166', '매체활용능력증진및역기능해소청소년인터넷스마트폰과의존치료비지원'],\n",
+       " ['38', '사회복지종사자상해보험가입지원'],\n",
+       " ['89', '서민층가스시설개선'],\n",
+       " ['310', '의료급여의료급여'],\n",
+       " ['156', '중앙아동보호전문기관운영'],\n",
+       " ['17163', '최저임금적용제외근로장애인전환지원']]"
+      ]
+     },
+     "execution_count": 216,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_welfares_list = new_welfares_df.values.tolist()\n",
+    "old_welfares_list = old_welfares_df['서비스명'].tolist()\n",
+    "diff_welfares = [welfare for welfare in new_welfares_list if welfare[1] not in old_welfares_list]\n",
+    "diff_welfares "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95da8b88",
+   "metadata": {},
+   "source": [
+    "### mysql에 new_welfare새로운 값 넣기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 217,
+   "id": "2b2ba243",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inner_id_list = inner_welfares_df['서비스아이디_y'].tolist()\n",
+    "sql_new_welfares_df = welfares_df[welfares_df['서비스아이디'].isin(inner_id_list)].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 218,
+   "id": "c50ed832",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 349 entries, 0 to 356\n",
+      "Data columns (total 5 columns):\n",
+      " #   Column  Non-Null Count  Dtype \n",
+      "---  ------  --------------  ----- \n",
+      " 0   서비스아이디  349 non-null    object\n",
+      " 1   서비스명    349 non-null    object\n",
+      " 2   서비스요약   349 non-null    object\n",
+      " 3   대표문의    349 non-null    object\n",
+      " 4   사이트     349 non-null    object\n",
+      "dtypes: object(5)\n",
+      "memory usage: 16.4+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "sql_new_welfares_df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "id": "89e30620",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = (\"\"\"INSERT INTO new_welfare (welfare_id, title, summary, calls, sites) VALUES (%s, %s, %s, %s, %s)\"\"\") \n",
+    "input_data=[tuple(x) for x in sql_new_welfares_df.to_records(index=False)]\n",
+    "cursor.executemany(query, input_data)\n",
+    "\n",
+    "cnxn.commit() "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea2ee8a7",
+   "metadata": {},
+   "source": [
+    "### mysql에 new_welfare_category 넣기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 219,
+   "id": "ba1a6f5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = (\"SELECT welfare_id, category_id FROM welfare_category\")\n",
+    "cursor.execute(query)\n",
+    "\n",
+    "old_categories = []\n",
+    "for old_category in cursor:\n",
+    "    old_categories.append([old_category[0], old_category[1]])\n",
+    "old_categories_df = pd.DataFrame(old_categories, columns=['서비스아이디', '카테고리'])\n",
+    "old_categories_df = old_categories_df.astype(str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 220,
+   "id": "f2edc471",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 1321 entries, 0 to 1320\n",
+      "Data columns (total 2 columns):\n",
+      " #   Column  Non-Null Count  Dtype \n",
+      "---  ------  --------------  ----- \n",
+      " 0   서비스아이디  1321 non-null   object\n",
+      " 1   카테고리    1321 non-null   object\n",
+      "dtypes: object(2)\n",
+      "memory usage: 20.8+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "old_categories_df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 221,
+   "id": "b1dbec01",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 1321 entries, 0 to 1320\n",
+      "Data columns (total 2 columns):\n",
+      " #   Column  Non-Null Count  Dtype \n",
+      "---  ------  --------------  ----- \n",
+      " 0   서비스아이디  1321 non-null   object\n",
+      " 1   카테고리    1321 non-null   object\n",
+      "dtypes: object(2)\n",
+      "memory usage: 31.0+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "old_categories_df.drop_duplicates().info() # 중복된 값이 존재하지 않음"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 222,
+   "id": "2f56158a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_categories_df = pd.merge(old_categories_df, inner_welfares_df, how='inner', left_on='서비스아이디', right_on='서비스아이디_x')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 223,
+   "id": "7690a675",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sql_new_categories_df = new_categories_df[['서비스아이디_y', '카테고리']].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "id": "f48a7a83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = (\"\"\"INSERT INTO new_welfare_category (welfare_id, category_id) VALUES (%s, %s)\"\"\") \n",
+    "input_data=[tuple(x) for x in sql_new_categories_df.to_records(index=False)]\n",
+    "cursor.executemany(query, input_data)\n",
+    "\n",
+    "cnxn.commit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfc7c773",
+   "metadata": {},
+   "source": [
+    "### 8개의 데이터에 대해서 수작업하기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 224,
+   "id": "632ef719",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "id_list = [id[0] for id in diff_welfares]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 225,
+   "id": "576e71cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "addition_welfares_df = welfares_df[welfares_df['서비스아이디'].isin(id_list)].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 226,
+   "id": "9eb752d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 8 entries, 87 to 329\n",
+      "Data columns (total 5 columns):\n",
+      " #   Column  Non-Null Count  Dtype \n",
+      "---  ------  --------------  ----- \n",
+      " 0   서비스아이디  8 non-null      object\n",
+      " 1   서비스명    8 non-null      object\n",
+      " 2   서비스요약   8 non-null      object\n",
+      " 3   대표문의    8 non-null      object\n",
+      " 4   사이트     8 non-null      object\n",
+      "dtypes: object(5)\n",
+      "memory usage: 384.0+ bytes\n"
+     ]
+    }
+   ],
+   "source": [
+    "addition_welfares_df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 228,
+   "id": "4a263731",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = (\"\"\"INSERT INTO new_welfare (welfare_id, title, summary, calls, sites) VALUES (%s, %s, %s, %s, %s)\"\"\") \n",
+    "input_data=[tuple(x) for x in addition_welfares_df.to_records(index=False)]\n",
+    "cursor.executemany(query, input_data)문\n",
+    "\n",
+    "cnxn.commit() "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5336c36e",
+   "metadata": {},
+   "source": [
+    "### KSBERT 학습을 위한 csv파일로 만들기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "325c2b62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "welfares_for_embedding = welfares_df[['서비스아이디', '서비스명', '서비스요약']].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "58a9380c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "welfares_for_embedding['full'] = welfares_df['서비스명']+' '+welfares_df['서비스요약']\n",
+    "welfares_for_embedding.rename(columns = {'서비스아이디':'welfare_id','서비스명':'title', '서비스요약':'summary'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "38d585ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "welfares_for_embedding.to_csv(\"welfare_for_embedding.csv\", index=False, encoding=\"utf-8-sig\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
프로보노 데이터를 공공데이터로 대체

### 📑 구현한 내용
- [x] 공공데이터 API를 사용해 복지 정보 가져오기
- [x] 기존 DB와 비교하여 category를 적재
- [x] 8개의 기존 DB와 맞지 않는 데이터는 수작업

### 🚧 주의 사항

8개의 기존 DB와 다른 복지의 경우 category number를 수작업으로 지정해줌
