### PR TITLE
[BE] Session 유지 API에 재발급된 FCM 토큰을 받을수 있는 기능 추가 

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -26,6 +26,13 @@ exports.userSession = (req, res, next) => {
                 "statusCode" : 200,
                 "token" : req.body.token
             }));
+
+            // request에 refresh된 토큰이 함께 온다면 db를 업데이트한다.
+            if (req.body.refreshed_ftoken != undefined) {   
+                User.update({
+                    user_mToken: req.body.refreshed_ftoken // refresh된 firebase token 
+                }, { where: { user_id: user_info.user_id }})
+            }
         }
         else {
             // 실패 json 보내기


### PR DESCRIPTION
## [BE] Session 유지 API에 재발급된 FCM 토큰을 받을수 있는 기능 추가 

### 🔨 작업 내용 설명
- [x] Session 유지 api에 "refreshed_ftoken" 값을 추가하여 클라이언트 측에서 fcm 토큰이 재발급될 경우 해당 토큰값을 서버에 전달하여 DB의 저장된 fcm 토큰 값이 항상 최신화될 수 있도록 작업

### 📑 구현한 내용
- Session api에 refreshed_ftoken 필드 추가 
- 제공받은 fcm 토큰을 해당 사용자의 db에 갱신하도록 작업 
