### PR TITLE
[DATA] Fix top welfare_id extract function

### DIFF
--- a/ai/KoSentenceBERTchatbot/KoSentenceBERT/main.py
+++ b/ai/KoSentenceBERTchatbot/KoSentenceBERT/main.py
@@ -2,7 +2,7 @@ from sentence_transformers import SentenceTransformer
 import pandas as pd
 import json
 
-from utils import extract_top
+from utils import extract_top, extract_welfare_id
 
 from flask import Flask, request 
 
@@ -33,9 +33,11 @@ def method():
         
         standard = params['standard']
         em_se_embedding = corpus_embedding['embedding_'+standard]
+        corpus_welfare_id = corpus_embedding['welfare_id']
 
         top_k=3
         top_results = extract_top(em_se_embedding, query_embedding, top_k)
+        top_welfare_id = extract_welfare_id(corpus_welfare_id, top_results)
         
-        return json.dumps({"recommend":top_results},ensure_ascii=False)
+        return json.dumps({"recommend":top_welfare_id},ensure_ascii=False)
 

--- a/ai/KoSentenceBERTchatbot/KoSentenceBERT/utils.py
+++ b/ai/KoSentenceBERTchatbot/KoSentenceBERT/utils.py
@@ -5,7 +5,7 @@ from numpy.linalg import norm
 import json
 
 def cos_sim(A, B):
-       return dot(A, B)/(norm(A)*norm(B)) ## A, B는 array
+      return dot(A, B)/(norm(A)*norm(B)) ## A, B는 array
 
 def extract_top(em_se_embedding, em_query, top_k): 
     cos_sim_query = pd.DataFrame()
@@ -14,3 +14,7 @@ def extract_top(em_se_embedding, em_query, top_k):
     cos_sim_query = cos_sim_query.sort_values("cos_sim", ascending=False)
     top_sm = cos_sim_query.index[0:top_k].tolist()
     return top_sm
+
+def extract_welfare_id(corpus_welfare_id, top_results): 
+    top_welfare_id = corpus_welfare_id[top_results].tolist()
+    return top_welfare_id


### PR DESCRIPTION

### 🔨 작업 내용 설명

- 챗봇 결과가 이상하게 나오는 문제가 있었고, 문서가 연속적이라는 가정하에 index를 top으로 뽑고 있었습니다.
- index 대신 정확한 welfare_id를 뽑도록 수정했습니다.

### 📑 구현한 내용

- [x] 오류 뱔견
- [x] welfare_id 추출 함수 생성 

### 🚧 주의 사항

DB, backend, 딥러닝 모두 약간의 오류들이 있었기 때문에 원인을 발견하는 데 시간이 걸렸습니다.
개발 마지막에 점검을 꼼꼼히 하지 않은 게 원인인 것 같습니다.

[### 스크린 샷]

[issue | close] #[ISSUE_NUMBER]
