### PR TITLE
Fix/TW-203 : MainActivity 뒤로 가기 기능 에러 수정 및 ChatActivity 모드 전환시 챗봇 응답 추가

### DIFF
--- a/client/.idea/misc.xml
+++ b/client/.idea/misc.xml
@@ -21,8 +21,10 @@
         <entry key="app/src/main/res/drawable/toggle_chat_mode_selector.xml" value="0.24074074074074073" />
         <entry key="app/src/main/res/font/font.xml" value="0.22962962962962963" />
         <entry key="app/src/main/res/layout/activity_chat.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/activity_detail.xml" value="0.335" />
         <entry key="app/src/main/res/layout/activity_intro.xml" value="0.22" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/activity_main_view_all.xml" value="0.13597376387487387" />
         <entry key="app/src/main/res/layout/activity_map.xml" value="0.25" />
         <entry key="app/src/main/res/layout/activity_my_profile.xml" value="0.21" />
         <entry key="app/src/main/res/layout/activity_profile.xml" value="0.25" />

--- a/client/app/src/main/java/com/product/welfareapp/ChatActivity.java
+++ b/client/app/src/main/java/com/product/welfareapp/ChatActivity.java
@@ -165,8 +165,8 @@ public class ChatActivity extends AppCompatActivity {
         });
          */
 
-        Button toggle_chat_mode_1 = (Button)findViewById(R.id.toggle_chat_mode_1);
-        Button toggle_chat_mode_2 = (Button)findViewById(R.id.toggle_chat_mode_2);
+        Button toggle_chat_mode_1 = (Button)findViewById(R.id.toggle_chat_mode_1); // 복지정보 기능
+        Button toggle_chat_mode_2 = (Button)findViewById(R.id.toggle_chat_mode_2); // 일상대화 기능
 
         if(chat_mode == 0){
             toggle_chat_mode_1.setBackgroundResource(R.drawable.toggle_chat_mode_on);
@@ -180,18 +180,28 @@ public class ChatActivity extends AppCompatActivity {
         toggle_chat_mode_1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                // 복지정보 기능
                 chat_mode = 0;
                 toggle_chat_mode_1.setBackgroundResource(R.drawable.toggle_chat_mode_on);
                 toggle_chat_mode_2.setBackgroundResource(R.drawable.toggle_chat_mode_off);
+
+                chatModelArrayList.add(new ChatModel("복지정보 알림 모드로 전환합니다. ", BOT_KEY, null, null, 0, -1, token));
+                chatRVAdapter.notifyDataSetChanged();
+                chatRVList.scrollToPosition(chatRVList.getAdapter().getItemCount() - 1);
             }
         });
 
         toggle_chat_mode_2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                // 일상대화 기능
                 chat_mode = 1;
                 toggle_chat_mode_2.setBackgroundResource(R.drawable.toggle_chat_mode_on);
                 toggle_chat_mode_1.setBackgroundResource(R.drawable.toggle_chat_mode_off);
+
+                chatModelArrayList.add(new ChatModel("일상 대화 모드로 전환합니다. ", BOT_KEY, null, null, 0, -1, token));
+                chatRVAdapter.notifyDataSetChanged();
+                chatRVList.scrollToPosition(chatRVList.getAdapter().getItemCount() - 1);
             }
         });
 

--- a/client/app/src/main/java/com/product/welfareapp/ListActivity.java
+++ b/client/app/src/main/java/com/product/welfareapp/ListActivity.java
@@ -75,10 +75,14 @@ public class ListActivity extends AppCompatActivity {
         btn_back.setOnClickListener(new View.OnClickListener(){
             @Override
             public void onClick(View v) {
+                /**
+                 * 2022.08.28 : replace startActivity to onBackPressed
                 Intent intent = new Intent(ListActivity.this, MainActivity.class);
                 intent.putExtras(bundle);
                 startActivity(intent);
                 finish();
+                */
+                ListActivity.super.onBackPressed();
             }
         });
 

--- a/client/app/src/main/java/com/product/welfareapp/MainActivity.java
+++ b/client/app/src/main/java/com/product/welfareapp/MainActivity.java
@@ -110,7 +110,7 @@ public class MainActivity extends AppCompatActivity {
                 Intent intent = new Intent(MainActivity.this, MainViewAllActivity.class);
                 intent.putExtras(bundle);
                 startActivity(intent);
-                finish();
+                // finish();
             }
         });
 

--- a/client/app/src/main/java/com/product/welfareapp/MainRVAdapter.java
+++ b/client/app/src/main/java/com/product/welfareapp/MainRVAdapter.java
@@ -66,6 +66,8 @@ public class MainRVAdapter extends RecyclerView.Adapter<MainRVAdapter.ViewHolder
                     Intent intent = new Intent(context, com.product.welfareapp.ListActivity.class);
                     intent.putExtras(bundle);
                     context.startActivity(intent);
+                    // main activity should be finished
+
                 }
                 catch(Exception err){
                     Log.v("Category to ListActivity intent process","error");

--- a/client/app/src/main/java/com/product/welfareapp/MainViewAllActivity.java
+++ b/client/app/src/main/java/com/product/welfareapp/MainViewAllActivity.java
@@ -71,10 +71,14 @@ public class MainViewAllActivity extends AppCompatActivity {
         btn_back.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                /**
+                 * 2022.08.28 : replace startActivity to onBackPressed
                 Intent intent = new Intent(MainViewAllActivity.this, MainActivity.class);
                 intent.putExtras(bundle);
                 startActivity(intent);
                 finish();
+                 */
+                MainViewAllActivity.super.onBackPressed();
             }
         });
     }
@@ -85,13 +89,7 @@ public class MainViewAllActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        if (back_pressed + 2000 > System.currentTimeMillis()){
-            super.onBackPressed();
-        }
-        else {
-            Toast.makeText(getBaseContext(), "뒤로가기 버튼을 한번 더 누르면 앱이 종료됩니다.", Toast.LENGTH_SHORT).show();
-        }
-        back_pressed = System.currentTimeMillis();
+        super.onBackPressed();
     }
 
     public synchronized void requestRecommendWelfareInfoAll(String token, final VolleyCallBack volleyCallBack){


### PR DESCRIPTION
## [FE] Fix/TW-203 : MainActivity 뒤로 가기 기능 에러 수정 및 ChatActivity 모드 전환시 챗봇 응답 추가

### 🔨 작업 내용 설명
- MainActivity에서 ListView 혹은 Recommend Welfare Info List 열람 후 뒤로가기 버튼 시행시 발생하게 되는 이중 앱 실행 해결
- 기기 내 뒤로 가기 버튼 및 앱 내 구성 항목인 뒤로가기 버튼 모두 동일하게 MainActivity로 전환될 수 있도록 수정함
- ChatActivity에서 mode 전환시 챗봇에서 모드 변환 관련 안내 응답값 출력

### 📑 구현한 내용
- ListActivity 및 MainViewAllActivity에서 backPressed() 함수를 동일하게 이전 세션으로 반환하는 형태로 재구현함
- 앱 내 UI로 구현된 뒤로 가기 버튼 누를 경우, 이전 List 항목과 관련된 activity는 모두 finish()를 통해 종료
- ChatActivity에서 mode 전환시 챗봇에서 ChatModelList에 default로 구현된, 모드 변환 관련 안내 텍스트를 출력

### 🚧 주의 사항
- 특이사항 없음

[close] #[FE] Fix/TW-203 : MainActivity 뒤로 가기 기능 에러 수정 및 ChatActivity 모드 전환시 챗봇 응답 추가 (release)
